### PR TITLE
Move CLI to commander

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 ![](https://img.shields.io/david/ajfisher/nodebots-interchange.svg)
 ![](https://img.shields.io/github/issues/ajfisher/nodebots-interchange.svg)
 
-Provides a mechanism to use custom backpacks and firmatas in your nodebots easily 
+Provides a mechanism to use custom backpacks and firmatas in your nodebots easily
 and without needing to use arduino or compile firmwares and all their dependencies.
 
 Want to use a ping sensor on your nodebot or play around with neopixels? Plug in
-your arduino or backpack, install the relevant firmware with interchange and 
+your arduino or backpack, install the relevant firmware with interchange and
 start building that nodebot.
 
 It's as easy as:
@@ -25,7 +25,7 @@ like npm for your backpacks.
 Interchange provides the following:
 
 * A specification for how backpack devices should behave
-* An installation method for backpack firmware onto target boards to make 
+* An installation method for backpack firmware onto target boards to make
 backpack firmware selection and installation easy.
 * A method of updating select parts of the firmware if required without recompilation.
 * An ability to install Standard or Custom Firmatas to a board.
@@ -34,17 +34,17 @@ backpack firmware selection and installation easy.
 ## Installation
 
 It is recommended to install nodebots-interchange locally so different versions
-can coexist as part of projects. If you do this, make sure the node modules 
+can coexist as part of projects. If you do this, make sure the node modules
 .bin directory is on your path, like this:
 
 ```
 export PATH=./node_modules/.bin:$PATH
 ```
 
-After that just install locally using npm 
+After that just install locally using npm
 
 ```
-npm install ajfisher/nodesbots-interchange
+npm install ajfisher/nodebots-interchange
 ```
 
 Or alternatively
@@ -69,11 +69,11 @@ section below.
 In general:
 
 ```
-interchange install <firmware> -p <port> -a <board_type> -i <I2C_address> [--firmata]
+interchange install <firmware> -p <port> -a <board_type> -i <I2C_address> [--firmata [firmata]]
 ```
 
 Where `<firmware>` is the name of the firmware you would like to flash to the board,
-`<port>` is the name of the serial port you want to use, `<board_type>` is the 
+`<port>` is the name of the serial port you want to use, `<board_type>` is the
 specific type of board you would like to use and `<I2C_address>` is an optional
 parameter allowing you to change the default address of the I2C device.
 
@@ -106,7 +106,7 @@ are firmata capable or not.
 interchange list
 ```
 
-Get a list of all the available serial devices you can see (use the --verbose 
+Get a list of all the available serial devices you can see (use the --verbose
 switch if you want to get much more detail about the devices.
 
 ```
@@ -121,7 +121,7 @@ interchange install hc-sr04 -a nano -p /dev/tty.wchserial1410
 ```
 
 Install the HC-SR04 backpack firmware to an arduino nano on port /dev/tty.wchserial1410
-however change the default I2C address to 0x65 instead. (Ensure configuration 
+however change the default I2C address to 0x65 instead. (Ensure configuration
 mode on the arduino is set).
 
 ```
@@ -130,7 +130,7 @@ interchange install hc-sr04 -a nano -p /dev/tty.wchserial1410 -i 0x65
 
 Install StandardFirmata on an arduino Uno at port /dev/tty.usbmodem1230
 
-``` 
+```
 interchange install StandardFirmata -a uno -p /dev/tty.usbmodem1230
 ```
 
@@ -140,7 +140,7 @@ Install the HC-SR04 custom firmata on an arduino Uno at port /dev/tty.usbmodem12
 interchange install hc-sr04 -a uno -p /dev/tty.usbmodem1230 --firmata
 ```
 
-Install a custom firmata (in this case for the mbot) onto an arduino from a git 
+Install a custom firmata (in this case for the mbot) onto an arduino from a git
 repository and not from the interchange directory (good for testing in development) on port
 /dev/tty.wchserial1560
 
@@ -149,14 +149,14 @@ interchange install git+https://github.com/Makeblock-official/mbot_nodebots -p /
 ```
 
 Install a named custom firmata (in this case the mbot Bluetooth firmata) onto
-an arduino from git repo on port /dev/tty.wchserial1560 - note the use of 
-`--firmata=[name]` here.
+an arduino from git repo on port /dev/tty.wchserial1560 - note the use of
+`--firmata [name]` here.
 
 ```
-interchange install git+https://github.com/Makeblock-official/mbot_nodebots -p /dev/tty.wchserial1560 -a uno --firmata=bluetooth
+interchange install git+https://github.com/Makeblock-official/mbot_nodebots -p /dev/tty.wchserial1560 -a uno --firmata bluetooth
 ```
 
-Read the details of a backpack firmware on /dev/tty.usbmodem1130 to see what 
+Read the details of a backpack firmware on /dev/tty.usbmodem1130 to see what
 is on it.
 
 ```
@@ -179,29 +179,29 @@ Additional documentation: https://docs.google.com/document/d/1j6Jce2MUSA-V-I9iO6
 # Acknowledgements
 
 Interchange was born of an idea that came out of RobotsConf 2014 that started
-with a discussion about how to incorporate NeoPixel support into 
-[Firmata](https://github.com/firmata/arduino) and 
+with a discussion about how to incorporate NeoPixel support into
+[Firmata](https://github.com/firmata/arduino) and
 [Johnny-Five](https://github.com/rwaldron/johnny-five). Adding custom additions
 to firmata created numerous problems, not just with the bloat that it would
-cause in firmata but additionally the support requirements it would impose on 
+cause in firmata but additionally the support requirements it would impose on
 other IO Plugins as any custom instructions would then need to be supported as well.
 
 The end solution was to instead create a custom NodeBots "board", in the
 style of a "BackPack" (as used by AdaFruit & others in the hardware space) that
 would act as a bridge between "dumb" devices such as ultrasonic sensors,
-neopixels and touch screens that would then expose these components as I2C 
+neopixels and touch screens that would then expose these components as I2C
 devices. In this way, any nodebots capable board that can talk I2C (just about
 all of them) would be able to work with these components, not just those running
 firmata.
 
-As the project has developed, it was determined that being able to use it to 
+As the project has developed, it was determined that being able to use it to
 eliminate the need for Arduino for beginners was also useful and would use the
-same mechanism. 
+same mechanism.
 
 This project would not have seen light were it not for the following people:
 
 * Rick Waldron - believing this was a good approach and supporting the exploration
 of the idea to augment Johnny Five.
-* Suz Hinton - for the excellent avrgirl which provided considerable heavy lifting on the 
+* Suz Hinton - for the excellent avrgirl which provided considerable heavy lifting on the
 flashing side of things.
 * Andy Gelme, Luis Montes - for pushing me on backpacks and keep me moving.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ section below.
 In general:
 
 ```
-interchange install <firmware> -p <port> -a <board_type> -i <I2C_address> [--firmata [firmata]]
+interchange install <firmware> -p <port> -a <board_type> -i <I2C_address> [--firmata [name]]
 ```
 
 Where `<firmware>` is the name of the firmware you would like to flash to the board,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,7 +2,7 @@
 
 var program = require('commander');
 var version = require('../package.json').version;
-var Interchange = require('../interchange');
+var Interchange = require('../lib/interchange');
 var interchange = new Interchange();
 
 program
@@ -11,61 +11,27 @@ program
 program.command("list")
     .description("Lists all of the available firmwares")
     .alias("l")
-    .action(interchange.list_devices);
+    .action(interchange.list_devices.bind(interchange));
 
 program.command("ports")
     .description("Lists all of the attached boards and their ports")
     .alias("p")
     .option("-v, --verbose", "List with additional information")
-    .action(interchange.list_ports);
+    .action(interchange.list_ports.bind(interchange));
 
 program.command("read")
-    .description("Read firware info from port")
+    .description("Read firmware info from port")
     .alias("r")
     .option("-p, --port", "Serial port board is attached to")
-    .action(function (opts) {
-        if (!opts.port) {
-            console.error("Please provide a device path".red);
-            return;
-        }
-
-        interchange.get_firmware_info(opts.port);
-    });
+    .action(interchange.get_firmware_info.bind(interchange));
 
 program.command("install [firmware]")
     .description("Install specified firmware to board")
     .alias("i")
     .option("-a, --board <board>", "Type of board/AVR")
     .option("-p, --port <port>", "Serial port board is attached to")
-    .option("-f, --firmata", "Install firmata version of firmware")
-    .option("-i, --address <address>", "Specify I2C address")
-    .action(function (firmware, opts) {
-        if (!firmware) {
-            console.error("Please supply a firmware to install".red);
-            return;
-        }
-
-        var settings = {
-            board: opts.board || process.env.INTERCHANGE_BOARD || "nano",
-            port: opts.port || process.env.INTERCHANGE_PORT,
-            firmata: opts.firmata,
-            i2c_address: opts.address,
-        };
-
-        try {
-            interchange.check_firmware(firmware, settings, function(hex_path, tmp_dir, options) {
-
-                interchange.flash_firmware(hex_path, options, function() {
-                    // once complete destory the tmp_dir.
-                    if (tmp_dir) {
-                        interchange.clean_temp_dir(tmp_dir);
-                    }
-                });
-            });
-        } catch (e) {
-            console.error(e.red);
-            return;
-        }
-    });
+    .option("-f, --firmata [firmata]", "Install firmata version of firmware")
+    .option("-i, --address <address>", "Specify I2C address, eg 0x67")
+    .action(interchange.install_firmware.bind(interchange));
 
 program.parse(process.argv);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,7 +33,7 @@ program.command("read")
     });
 
 program.command("install [firmware]")
-    .description("Test")
+    .description("Install specified firmware to board")
     .alias("i")
     .option("-a, --board <board>", "Type of board/AVR")
     .option("-p, --port <port>", "Serial port board is attached to")

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,71 @@
+#! /usr/bin/env node
+
+var program = require('commander');
+var version = require('../package.json').version;
+var Interchange = require('../interchange');
+var interchange = new Interchange();
+
+program
+  .version(version);
+
+program.command("list")
+    .description("Lists all of the available firmwares")
+    .alias("l")
+    .action(interchange.list_devices);
+
+program.command("ports")
+    .description("Lists all of the attached boards and their ports")
+    .alias("p")
+    .option("-v, --verbose", "List with additional information")
+    .action(interchange.list_ports);
+
+program.command("read")
+    .description("Read firware info from port")
+    .alias("r")
+    .option("-p, --port", "Serial port board is attached to")
+    .action(function (opts) {
+        if (!opts.port) {
+            console.error("Please provide a device path".red);
+            return;
+        }
+
+        interchange.get_firmware_info(opts.port);
+    });
+
+program.command("install [firmware]")
+    .description("Test")
+    .alias("i")
+    .option("-a, --board <board>", "Type of board/AVR")
+    .option("-p, --port <port>", "Serial port board is attached to")
+    .option("-f, --firmata", "Install firmata version of firmware")
+    .option("-i, --address <address>", "Specify I2C address")
+    .action(function (firmware, opts) {
+        if (!firmware) {
+            console.error("Please supply a firmware to install".red);
+            return;
+        }
+
+        var settings = {
+            board: opts.board || process.env.INTERCHANGE_BOARD || "nano",
+            port: opts.port || process.env.INTERCHANGE_PORT,
+            firmata: opts.firmata,
+            i2c_address: opts.address,
+        };
+
+        try {
+            interchange.check_firmware(firmware, settings, function(hex_path, tmp_dir, options) {
+
+                interchange.flash_firmware(hex_path, options, function() {
+                    // once complete destory the tmp_dir.
+                    if (tmp_dir) {
+                        interchange.clean_temp_dir(tmp_dir);
+                    }
+                });
+            });
+        } catch (e) {
+            console.error(e.red);
+            return;
+        }
+    });
+
+program.parse(process.argv);

--- a/interchange.js
+++ b/interchange.js
@@ -223,8 +223,6 @@ Interchange.prototype.download_from_npm = function (firmware, options, cb) {
         manifest_objects.hexPath = "/" + manifest_objects.hexPath;
     }
 
-    console.log(base_path, manifest_objects.bins, options.board, manifest_objects.hexPath);
-
     var hex_path = path.join(base_path, manifest_objects.bins, options.board, manifest_objects.hexPath);
 
     cb(hex_path, null,  options);

--- a/lib/interchange.js
+++ b/lib/interchange.js
@@ -11,11 +11,11 @@ var http    = require('http');
 var path    = require("path");
 var tmp     = require('tmp');
 
-var creators = require('./lib/firmwares.json').creators;
-var firmwares = require('./lib/firmwares.json').firmwares;
-var interchange_client = require('./lib/interchange_client');
+var creators = require('./firmwares.json').creators;
+var firmwares = require('./firmwares.json').firmwares;
+var interchange_client = require('./interchange_client');
 var ic_client = new interchange_client.Client();
-var version = require('./package.json').version;
+var version = require('../package.json').version;
 
 var fw = null; // used to hold details of the firmware we want in it.
 
@@ -33,8 +33,7 @@ Interchange.prototype.clean_temp_dir = function (tmpdir) {
 };
 
 Interchange.prototype.list_devices = function () {
-    // this function lists out all of the devices available to have firmware
-    // installed.
+    // this function lists out all of the firmwares available to be installed.
 
     console.info("\nFirmwares available for backpacks. (f) denotes a firmata version is available\n");
     _.sortBy(firmwares, "name").forEach(function(firmware) {
@@ -71,6 +70,11 @@ Interchange.prototype.get_firmware_info = function (port) {
     // attempts to connect to an interchange firmware and get the
     // installed details.
 
+    if (!port) {
+        console.error("Please provide a device path".red);
+        return;
+    }
+
     ic_client.port = port;
 
     ic_client.on("error", function(err) {
@@ -105,6 +109,37 @@ Interchange.prototype.get_firmware_info = function (port) {
             this.close();
         }.bind(this));
     })
+};
+
+Interchange.prototype.install_firmware = function (firmware, opts) {
+
+    if (!firmware) {
+        console.error("Please supply a firmware to install".red);
+        return;
+    }
+
+    var settings = {
+        board: opts.board || process.env.INTERCHANGE_BOARD || "nano",
+        port: opts.port || process.env.INTERCHANGE_PORT,
+        firmata: opts.firmata,
+        i2c_address: opts.address,
+    };
+
+    try {
+        this.check_firmware(firmware, settings, function(hex_path, tmp_dir, options) {
+
+            this.flash_firmware(hex_path, options, function() {
+                // once complete destory the tmp_dir.
+                if (tmp_dir) {
+                    this.clean_temp_dir(tmp_dir);
+                }
+            }.bind(this));
+        }.bind(this));
+    } catch (e) {
+        console.error(e);
+        return;
+    }
+
 };
 
 Interchange.prototype.set_firmware_details = function (port, opts, cb) {
@@ -232,9 +267,12 @@ Interchange.prototype.download_from_npm = function (firmware, options, cb) {
 Interchange.prototype.download_from_github = function (firmware, options, cb) {
     // downloads the firmware from the GH repo
 
-    console.info("Retrieving manifest data from GitHub".magenta);
+    var self = this;
     var manifest_uri = null;
     var base_uri = null;
+
+    console.info("Retrieving manifest data from GitHub".magenta);
+
     if (firmware.repo.indexOf('git+https') == 0) {
         base_uri = "https://raw.githubusercontent.com" + firmware.repo.substring(22) + "/master";
         manifest_uri = base_uri + "/manifest.json?" + (new Date().getTime());
@@ -252,7 +290,7 @@ Interchange.prototype.download_from_github = function (firmware, options, cb) {
 
             if (err) {
                 console.error(err);
-                clean_temp_dir(tmp_dir);
+                self.clean_temp_dir(tmp_dir);
                 throw err;
             }
 
@@ -260,7 +298,7 @@ Interchange.prototype.download_from_github = function (firmware, options, cb) {
                 var manifest = JSON.parse(fs.readFileSync(manifest_files[0].path));
             } catch (e) {
                 console.error("Manifest file incorrect");
-                clean_temp_dir(tmp_dir);
+                self.clean_temp_dir(tmp_dir);
                 throw "Manifest file error"
             }
 
@@ -294,7 +332,7 @@ Interchange.prototype.download_from_github = function (firmware, options, cb) {
                 .run(function(err, hex_files) {
                     if (err) {
                         console.error(err);
-                        clean_temp_dir(tmp_dir);
+                        self.clean_temp_dir(tmp_dir);
                         throw err;
                     }
                     cb(hex_files[0].path, tmp_dir, options);

--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
   },
   "homepage": "https://github.com/ajfisher/nodebots-interchange#readme",
   "bin": {
-    "interchange": "bin/interchange.js"
+    "interchange": "bin/cli.js"
   },
   "dependencies": {
     "async": "^1.5.0",
     "avrgirl-arduino": "^1.4.15",
     "colors": "^1.1.2",
+    "commander": "^2.9.0",
     "download": "^4.4.1",
     "fs-extra": "^0.24.0",
     "lodash": "^3.10.1",


### PR DESCRIPTION
I ended up down kind of a weird road on this before coming back to reality. "Interchange" and the CLI itself are in separate files now. This is a result of thinking I needed to do something with commander that ended up being wrong. If you're not happy with this I can revert that portion.

However, I decided to commit it this way because it opens up the possibility of using interchange programmatically in the future. I tested as much as I could and everything seems fine.